### PR TITLE
Página "projetos brasileiros open source" readicionada.

### DIFF
--- a/projetos-brasileiros-open-source.md
+++ b/projetos-brasileiros-open-source.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: "Projetos brasileiros open source"
+published: true
+---
+
+# Segurança
+
+- [ebizzy](http://sourceforge.net/projects/ebizzy/) - GPL: BlackBox, webapplication test loader. É altamente segmentado.
+- [Firmament](http://sourceforge.net/projects/firmament/) - GPL: Tester e emulador de falhas de comunicação e segurança em sistemas distribuídos, baseado em behavior script.
+- [HLBR](http://hlbr.sourceforge.net/) - GPLv2: IPS de camada 2 baseado no projeto HOGWASH.
+- [OpenVaccine](http://sourceforge.net/projects/openvaccine/) - GPLv3: Ferramenta para proteger dispositivos USB com partições FAT-32 de malwares.
+- [OSSEC Attacking Log Analysis tools](http://www.ossec.net/) - GNUv3: Sistema de detecção de intrusão e análise de logs.
+- [PEV](http://sourceforge.net/projects/pev/) - GPLv3: PE analysis toolkit com utilitários específicos para análise de malware.
+- [StJude/StMichael](http://sourceforge.net/projects/stjude/) BSD: - O StJude/StMichael Project é um IDS Kernel-Level para proteger a integridade de um host.
+- [T50](http://t50.sourceforge.net/) - GNUv2: Injetor de pacotes multi-protocolo para sistemas *nix, suportando atualmente 15 protocolos.
+
+# Embarcados
+
+- [BRTOS](https://code.google.com/p/brtos/) - MIT: Sistema operacional de tempo real para embarcados.
+- [eLua](http://www.eluaproject.net/) - MIT: Ferramenta para uso da linguagem Lua para desenvolvimento embarcado.
+- [GPSNet](https://code.google.com/p/gpsnet/) - MIT: RTOS para Microcontroladores.
+
+# Scripting
+
+- [BOO](http://boo.codehaus.org/) - MIT license: linguagem de programação orientada a objeto de tipagem estática com sintaxe inspirada em python e com um foco especial.
+- [Clever](http://clever-lang.github.com/) - MIT license: linguagem de programação orientada a objeto de tipagem estática e de propósito geral. (Ainda em desenvolvimento)
+- [JsonCreator](http://github.com/bcsanches/JsonCreator) - zlib license: Uma biblioteca simples para geração de JSON sem precisar ficar manipulando strings e que detecta erros na formação do documento.
+- [Lua](http://lua.org/) - MIT license: Uma linguagem de script poderosa, rápida e leve.
+
+# Rede
+
+- [Tio](https://code.google.com/p/tio) - Apache License 2.0: Servidor de contêineres multiplataforma com foco no padrão "publish/subscribe".
+- [DistributedCL](http://sf.net/projects/distributedcl) - MIT License: Middleware de processamento distribuído em GPU com a API OpenCL.
+
+# Testes
+
+- [Unit Test framework (+ wizard for Visual C++)](http://www.thradams.com/codeblog/unittest.htm): Framework para geração de testes unitários e um wizard para geração de projetos de testes no Visual Studio.
+
+# Console (modo texto)
+
+- [Console conio](http://www.thradams.com/codeblog/console.htm): Para aqueles que sentem falta da conio.h do TurboC, uma implementação para Windows.
+
+# Ferramentas
+
+- [File Depends](http://www.thradams.com/codeblog/filedepends.htm): ferramenta que mostra os arquivos .h e suas dependências.
+- [dbf2txt](https://github.com/bcsanches/dbf2txt) - zlib: Ferramenta para extrair dados de arquivos db2 em formato texto.
+
+# Jogos
+
+- [Phobos](https://github.com/bcsanches/phobos3d/) - zlib: Motor 3d baseado em Ogre para desenvolvimento de jogos.
+- [Wadlib](https://github.com/bcsanches/wadlib) - zlib: Ferramenta para conversão de mapas e dados do Doom para formatos modernos.
+- [Easy2d](http://easy2d.sourceforge.net/): Biblioteca para desenvolvimento de jogos 2d em C++.
+- [Chien2d](http://code.google.com/p/chien2d/): Biblioteca para desenvolvimento de jogos 2d em C.
+- [Wintermoon](http://wintermoon.sourceforge.net/): Biblioteca para desenvolvimento de jogos 2d em C++.
+- [Seed Framework](http://www.seedframework.org/): Biblioteca para desenvolvimento de jogos 2d em C++.
+
+# Web
+
+- [Tufão](https://github.com/vinipsmaker/tufao): Uma API estilo Node.js para desenvolvimento Web com Qt/C++.
+
+# Outros
+
+- IPAF
+- OmniObjecs
+- PEV
+- hdump
+- troll2D
+- Othelo
+
+```
+TODO: Organizar melhor tudo disto.
+
+WISHLIST:
+
+ 1) Inserir um mínimo de 42 projetos, com nome, link do repositório oficial, uma breve descrição e o tipo de licença do projeto.
+ 2) Dividir a relação em categoria de projetos. ex: segurança, utilitário, MRNN, WTF...
+ 3) Quando ficar apresentável divulgar que esta relação existe.
+```


### PR DESCRIPTION
Baseado na página da antiga wiki: http://web.archive.org/web/20130424053916/http://www.ccppbrasil.org/wiki/ProjetosBrasileirosOpenSource
