### PR TITLE
Página "sites brasileiros" readicionada

### DIFF
--- a/sites-brasileiros.md
+++ b/sites-brasileiros.md
@@ -12,6 +12,7 @@ published: true
 - http://nullonerror.appspot.com/
 - http://0fx66.com/blog/programacao/linguagem-c/
 - http://blog.ricbit.com/search/label/cpp
+- http://www.hogpog.com.br/
 
 # Portais
 


### PR DESCRIPTION
Fonte: http://web.archive.org/web/20130424053631/http://www.ccppbrasil.org/wiki/SitesBrasileiros
