### PR TITLE
Páginas "sites gringos" readicionada

### DIFF
--- a/sites-gringos.md
+++ b/sites-gringos.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "Sites gringos"
+published: true
+---
+
+# Publicações
+
+[Revista Overload](http://en.wikipedia.org/wiki/Overload_%28magazine%29)/[accu.org](http://accu.org/): Publicação de alta qualidade voltada a vários assuntos relativos ao desenvolvimento de software com bastante foco em C++.


### PR DESCRIPTION
Fonte: http://web.archive.org/web/20130424054035/http://www.ccppbrasil.org/wiki/SitesGringos

Diferenças: Seções vazias não foram readicionadas. São elas: "Blogs", "Sites com artigos" e "Fóruns".
